### PR TITLE
Fix token

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,6 @@
     "showUnfiltered": true
   },
   "botSettings": {
-    "token": "process.env.DISCORD_TOKEN",
     "enableCommands": true,
     "prefix": "+",
     "defaultGame": "",

--- a/server.js
+++ b/server.js
@@ -34,7 +34,7 @@ bot = new Discord.Client({disabledEvents: ['TYPING_START', 'MESSAGE_DELETE', 'ME
 function login (firstStartup) {
   if (!firstStartup) bot = new Discord.Client({disabledEvents: ['TYPING_START', 'MESSAGE_DELETE', 'MESSAGE_UPDATE']})
 
-  bot.login(config.botSettings.token)
+  bot.login(process.env.DISCORD_TOKEN)
   .catch(err => {
     if (loginAttempts++ >= maxAttempts) throw new Error(`${bot.shard ? 'SH ' + bot.shard.id + ' ' : ''}Discord.RSS failed to login after ${maxAttempts} attempts.`)
     console.log(`${bot.shard ? 'SH ' + bot.shard.id + ' ' : ''}Discord.RSS could not login (${err}), retrying in 60 seconds...`)


### PR DESCRIPTION
1. JSON stores strings, when you say `"token": "process.env.DISCORD_TOKEN"` your `token` becomes a string called `process.env.DISCORD_TOKEN` instead of your actual variable
2. You just use variable **in** the script